### PR TITLE
Add yaml-loader + example Markdown containing React via Yaml

### DIFF
--- a/docs/99-secret/restaurants2.yml
+++ b/docs/99-secret/restaurants2.yml
@@ -1,0 +1,17 @@
+- id: bin4
+  name: Bin4 Burger Lounge
+  description: |
+    Pretty fancy burgers.
+    Half fries half salad is the trick
+  tags:
+    - burgers
+    - salad
+    - fries
+- id: tacofino
+  name: Tacofino
+  description: |
+    Mmm Superveg
+- name: Board Game Cafe
+  description: |
+    Wait does that count as a restaurant?
+    I mean, you do usually order food there...

--- a/docs/99-secret/yaml-content-example.md
+++ b/docs/99-secret/yaml-content-example.md
@@ -1,0 +1,11 @@
+---
+title: Yaml Content Example
+pagination_prev: null
+pagination_next: null
+unlisted: true
+---
+
+import RestaurantList from '@site/src/components/RestaurantList';
+import restaurants from './restaurants2.yml';
+
+<RestaurantList restaurants={restaurants} />

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,6 +51,21 @@ const config = {
         keywords: { boost: 10 },
       },
     }],
+    () => ({
+      name: "custom-yaml-loader",
+      configureWebpack() {
+        return {
+          module: {
+            rules: [
+              {
+                test: /\.ya?ml$/,
+                use: "yaml-loader",
+              },
+            ],
+          },
+        };
+      },
+    }),
   ],
 
   presets: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/types": "3.9.2"
+        "@docusaurus/types": "3.9.2",
+        "yaml-loader": "^0.8.1"
       },
       "engines": {
         "node": ">=20.0"
@@ -231,7 +232,6 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.44.0.tgz",
       "integrity": "sha512-/FRKUM1G4xn3vV8+9xH1WJ9XknU8rkBGlefruq9jDhYUAvYozKimhrmC2pRqw/RyHhPivmgZCRuC8jHP8piz4Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.44.0",
         "@algolia/requester-browser-xhr": "5.44.0",
@@ -357,7 +357,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2147,7 +2146,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2170,7 +2168,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2280,7 +2277,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2702,7 +2698,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3408,7 +3403,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
       "integrity": "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/babel": "3.9.2",
         "@docusaurus/bundler": "3.9.2",
@@ -3590,7 +3584,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
       "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -4287,7 +4280,6 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -4606,7 +4598,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4984,7 +4975,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.6.tgz",
       "integrity": "sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5341,7 +5331,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5427,7 +5416,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5473,7 +5461,6 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.44.0.tgz",
       "integrity": "sha512-f8IpsbdQjzTjr/4mJ/jv5UplrtyMnnciGax6/B0OnLCs2/GJTK13O4Y7Ff1AvJVAaztanH+m5nzPoUq6EAy+aA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.10.0",
         "@algolia/client-abtesting": "5.44.0",
@@ -5962,7 +5949,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -6934,7 +6920,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -8463,7 +8448,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10242,6 +10226,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/javascript-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.1.0.tgz",
+      "integrity": "sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-util": {
       "version": "29.7.0",
@@ -13230,7 +13221,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13746,7 +13736,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14650,7 +14639,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15445,7 +15433,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15455,7 +15442,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15511,7 +15497,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -15540,7 +15525,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -17552,8 +17536,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -17966,7 +17949,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18174,7 +18156,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -18786,6 +18767,34 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/yaml-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.8.1.tgz",
+      "integrity": "sha512-BCEndnUoi3BaZmePkwGGe93txRxLgMhBa/gE725v1/GHnura8QvNs7c4+4C1yyhhKoj3Dg63M7IqhA++15j6ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "javascript-stringify": "^2.0.1",
+        "loader-utils": "^2.0.0",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
@@ -18803,7 +18812,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.9.2",
-    "@docusaurus/types": "3.9.2"
+    "@docusaurus/types": "3.9.2",
+    "yaml-loader": "^0.8.1"
   },
   "browserslist": {
     "production": [

--- a/src/components/RestaurantList.js
+++ b/src/components/RestaurantList.js
@@ -1,0 +1,34 @@
+import restaurantListDefault from "./restaurants.yml";
+
+function Restaurant({ name, description, tags }) {
+  return (
+    <div className="col col--4">
+      <div>
+        <h3>{name}</h3>
+      </div>
+      <div>{description}</div>
+      {tags && tags.length > 0 && (
+        <ul>
+          {tags.map((tag, index) => (
+            <li key={index}>{tag}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function RestaurantList({restaurants = restaurantListDefault}) {
+  console.log("Parsed Yaml:", restaurants, JSON.stringify(restaurants, null, 2));
+  return (
+    <section>
+      <div className="container">
+        <div className="row">
+          {restaurants.map((restaurant, idx) => (
+            <Restaurant key={idx} {...restaurant} />
+          ))} 
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/restaurants.yml
+++ b/src/components/restaurants.yml
@@ -1,0 +1,13 @@
+- id: bin4
+  name: Bin4 Burger Lounge
+  description: |
+    Pretty fancy burgers.
+    Half fries half salad is the trick
+  tags:
+    - burgers
+    - salad
+    - fries
+- id: tacofino
+  name: Tacofino
+  description: |
+    Mmm Superveg


### PR DESCRIPTION
Here's an example of yml-based content being rendered on a page via React. See http://localhost:3000/secret/yaml-content-example

It seems to work nicely with hot-reloading, so edits to the yml appear immediately on the page. Within React/javascript, the imported data behaves like a json array/object, which you can see from the debug console log I left in:

<img width="1209" height="550" alt="2025_11_29_01-59-33_firefox" src="https://github.com/user-attachments/assets/c1f67fdf-549e-4681-a875-7bebe10d9e92" />

I chose to make the React components in src/components, but you can (I guess) inline them directly into your Markdown pages if you have one-offs. 
I also made RestaurantList have a default `restaurantListDefault`, so if you just render `<RestaurantList />` on a page, it'll use `src/components/restaurants.yml` for data, whereas my page imports the `./restaurants2.yml` beside it, and passes that in as a prop to the component, overriding the default. Just to demonstrate those React component concepts and give ya options on how you want to organize data vs rendering :)